### PR TITLE
Updates for copy to archive lambda error.

### DIFF
--- a/copy_to_glacier_lambda/README.md
+++ b/copy_to_glacier_lambda/README.md
@@ -1,0 +1,94 @@
+## Adding Copy To Glacier Lambda
+Include {prefix}-glacier in buckets which should be created in cumulus deployment. GHRC adds the following to cumulus-tf/terraform.tfvars.example within our buckets dictionary
+```
+glacier = {
+    name = "${TF_VAR_glacier_bucket}"
+    type = "private"
+  }
+```
+Add the relative path to the copy to lambda source code to cumulus-tf/lambdas.tf with your other locals
+```
+orca_copy_to_glacier_lambda_path  = "../operational-recovery-cloud-archive/copy_to_glacier_lambda/dist/copy_to_glacier_lambda.zip"
+```
+Add the source code hash to cumulus-tf/lambdas.tf with your other locals
+```
+orca_copy_to_glacier_lambda_hash  = filemd5(local.orca_copy_to_glacier_lambda_path)
+```
+Add the copy to glacier terraform module to cumulus-tf/lambdas.tf
+```
+resource "aws_lambda_function" "copy_to_glacier" {
+  function_name    = "${var.prefix}-copy_to_glacier"
+  filename         = "${local.orca_copy_to_glacier_lambda_path}"
+  source_code_hash = "${local.orca_copy_to_glacier_lambda_hash}"
+  handler          = "handler.handler"
+  role             = module.cumulus.lambda_processing_role_arn
+  runtime          = "python3.7"
+  memory_size      = 2240
+  timeout          = 600 # 10 minutes
+
+  tags = local.default_tags
+  environment {
+    variables = {
+      system_bucket               = var.system_bucket
+      stackName                   = var.prefix
+      CUMULUS_MESSAGE_ADAPTER_DIR = "/opt/"
+    }
+  }
+
+  vpc_config {
+    subnet_ids         = list(module.ngap.ngap_subnets_ids[0])
+    security_group_ids = [aws_security_group.no_ingress_all_egress.id]
+  }
+}
+```
+Add the copy to glacier step into your cumulus workflow. GHRC adds this step into our ingest_granule_workflow.tf file after our PostToCMR step.
+```
+      "Next":"CopyToGlacier"
+      },
+      "CopyToGlacier":{
+         "Parameters":{
+            "cma":{
+               "event.$":"$",
+               "task_config":{
+                  "bucket":"{$.meta.buckets.internal.name}",
+                  "buckets":"{$.meta.buckets}",
+                  "distribution_endpoint":"{$.meta.distribution_endpoint}",
+                  "files_config":"{$.meta.collection.files}",
+                  "fileStagingDir":"{$.meta.collection.url_path}",
+                  "granuleIdExtraction":"{$.meta.collection.granuleIdExtraction}",
+                  "collection":"{$.meta.collection}",
+                  "cumulus_message":{
+                     "input":"{[$.payload.granules[*].files[*].filename]}",
+                     "outputs":[
+                        {
+                           "source":"{$}",
+                           "destination":"{$.payload}"
+                        }
+                     ]
+                  }
+               }
+            }
+         },
+         "Type":"Task",
+         "Resource":"${aws_lambda_function.copy_to_glacier.arn}",
+         "Catch":[
+            {
+               "ErrorEquals":[
+                  "States.ALL"
+               ],
+               "ResultPath":"$.exception",
+               "Next":"WorkflowFailed"
+            }
+         ],
+         "Retry":[
+            {
+               "ErrorEquals":[
+                  "States.ALL"
+               ],
+               "IntervalSeconds":2,
+               "MaxAttempts":3
+            }
+         ],
+         "Next":"WorkflowSucceeded"
+      },
+```

--- a/postgres.tf
+++ b/postgres.tf
@@ -54,7 +54,6 @@ resource "aws_ssm_parameter" "drdb-admin-pass" {
   type  = "SecureString"
   value = "${var.postgres_user_pw}"
   tags = var.default_tags
-  overwrite = true
 }
 
 resource "aws_ssm_parameter" "drdb-user-pass" {
@@ -62,7 +61,6 @@ resource "aws_ssm_parameter" "drdb-user-pass" {
   type  = "SecureString"
   value = "${var.database_app_user_pw}"
   tags = var.default_tags
-  overwrite = true
 }
 
 resource "aws_ssm_parameter" "drdb-host" {
@@ -70,5 +68,4 @@ resource "aws_ssm_parameter" "drdb-host" {
   type  = "String"
   value = "${aws_db_instance.postgresql.address}"
   tags = var.default_tags
-  overwrite = true
 }

--- a/tasks/copy_files_to_archive/copy_files_to_archive.py
+++ b/tasks/copy_files_to_archive/copy_files_to_archive.py
@@ -52,6 +52,7 @@ def task(records, retries, retry_sleep_secs):
         Raises:
             CopyRequestError: Thrown if there are errors with the input records or the copy failed.
     """
+
     files = get_files_from_records(records)
     attempt = 1
     s3 = boto3.client('s3')  # pylint: disable-msg=invalid-name
@@ -294,7 +295,7 @@ def handler(event, context):      #pylint: disable-msg=unused-argument
             The same dict that is returned for a successful copy, will be included in the
             message, with 'success' = False for the files for which the copy failed.
     """
-
+    print(event)
     logging.basicConfig(level=logging.INFO,
                         format='%(levelname)s: %(asctime)s: %(message)s')
     try:

--- a/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
+++ b/tasks/extract_filepaths_for_granule/extract_filepaths_for_granule.py
@@ -5,6 +5,7 @@ Description:  Extracts the keys (filepaths) for a granule's files from a Cumulus
 """
 
 import re
+import os
 
 from cumulus_logger import CumulusLogger
 from run_cumulus_task import run_cumulus_task
@@ -30,6 +31,7 @@ def task(event, context):    #pylint: disable-msg=unused-argument
         Raises:
             ExtractFilePathsError: An error occurred parsing the input.
     """
+    print(event)
     result = {}
     try:
         regex_buckets = get_regex_buckets(event)
@@ -42,7 +44,8 @@ def task(event, context):    #pylint: disable-msg=unused-argument
             gran['granuleId'] = ev_granule['granuleId']
             for afile in ev_granule['files']:
                 level = "event['input']['granules'][]['files']"
-                file_name = afile['fileName']
+                file_name = os.path.basename(afile['fileName']) if \
+                    re.search('^s3://', afile['fileName']) else afile['fileName']
                 fkey = afile['key']
                 dest_bucket = None
                 for key in regex_buckets:

--- a/tasks/request_files/request_files.py
+++ b/tasks/request_files/request_files.py
@@ -48,6 +48,7 @@ def task(event, context):              #pylint: disable-msg=unused-argument
         Raises:
             RestoreRequestError: Thrown if there are errors with the input request.
     """
+    print(event)
     try:
         exp_days = int(os.environ['RESTORE_EXPIRE_DAYS'])
     except KeyError:


### PR DESCRIPTION
Updated postgres.tf to avoid overwriting parameters- if need to change, instead remove the parameter from aws parameter store before deploying.
Updated request_files.py to print event for ease of troubleshooting.
Updated extract_filepaths_for_granule.py to fix regex issue- regex was looking for just basename while full s3 path was passed as input.